### PR TITLE
Fix topmenu if expr to match on wechall link

### DIFF
--- a/GLOBALHEADER.shtml
+++ b/GLOBALHEADER.shtml
@@ -43,7 +43,7 @@
 	<li><a href="/wargames/">Wargames</a></li>
 	<!--#endif -->
 
-	<!--#if expr="${DOCUMENT_URI}=/\/about\/wechall" -->
+	<!--#if expr="${DOCUMENT_URI}=/\/about\/wechall.shtml" -->
 	<li><a class='selected' href="/about/wechall.shtml">WeChall&nbsp;Scoring</a></li>
 	<!--#else -->
 	<li><a href="/about/wechall.shtml">WeChall&nbsp;Scoring</a></li>


### PR DESCRIPTION
Use the full `DOCUMENT_URI` link to match on the new wechall page URI, and not always show its tab in the topmenu bar as active.
