### PR TITLE
Add diff to useful commands in bandit18

### DIFF
--- a/wargames/bandit/bandit18.md
+++ b/wargames/bandit/bandit18.md
@@ -12,5 +12,5 @@ passwords.new**. The password for the next level is in
 
 Commands you may need to solve this level
 -----------------------------------------
-cat, grep, ls
+cat, grep, ls, diff
 


### PR DESCRIPTION
I think `diff` is missing because I don't see how `cat` and `grep` might be used in order to show diffs between files. However, maybe I'm wrong! ;)
