### PR TITLE
Patch 1

### DIFF
--- a/wargames/bandit/bandit8.md
+++ b/wargames/bandit/bandit8.md
@@ -11,9 +11,3 @@ next to the word **millionth**
 Commands you may need to solve this level
 -----------------------------------------
 grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd
-
-Helpful Reading Material
-------------------------
-- [The unix commandline: pipes and redirects][]
-
-[The unix commandline: pipes and redirects]: http://www.westwind.com/reference/os-x/commandline/pipes.html

--- a/wargames/bandit/bandit9.md
+++ b/wargames/bandit/bandit9.md
@@ -12,3 +12,8 @@ Commands you may need to solve this level
 -----------------------------------------
 grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd
 
+Helpful Reading Material
+------------------------
+- [The unix commandline: pipes and redirects][]
+
+[The unix commandline: pipes and redirects]: http://www.westwind.com/reference/os-x/commandline/pipes.html


### PR DESCRIPTION
moved the link from bandit8 to bandit9, as the user will need to know about piping in bandit9 only. In bandit8 you can use grep directly.
