### PR TITLE
Mrshu/title fixes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,11 @@
 <link rel="stylesheet" href="/css/highlightcode.css">
 <script src="/js/highlight.min.js"></script>
 <script src="/js/otwcrap.js"></script>
-<title>{{page.title}}</title>
+{% if page.title != nil %}
+<title>OverTheWire: {{page.title}}</title>
+{% else %}
+<title>OverTheWire</title>
+{% endif %}
 </head>
 <body>
 <div id="sitename"><a href="/">OverTheWire</a></div>

--- a/about/contact.md
+++ b/about/contact.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 listabout: true
+title: Contact Us
 ---
+
 Contact Us
 ==========
 

--- a/about/index.md
+++ b/about/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 listabout: true
+title: Contributing
 ---
+
 Contributing
 ============
 

--- a/about/us.md
+++ b/about/us.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 listabout: true
+title: About Us
 ---
 
 About Us

--- a/about/wechall.md
+++ b/about/wechall.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 listabout: true
+title: WeChall Scoreboard
 ---
+
 WeChall Scoreboard
 ==================
 

--- a/js/otwcrap.js
+++ b/js/otwcrap.js
@@ -76,8 +76,10 @@ function renderLevelTitle(name, level) {
 	} else {
 		title = capitaliseFirstLetter(name) + " Level "+level+" &rarr; Level "+(level+1);
 	}
-
         newDiv.innerHTML = "<h1>"+title+"</h1>";
+
+        // also set the webpage title
+        document.title += ": " + title;
     };
     oReq.open("GET", "/games.json", true);
     oReq.send();

--- a/news/index.md
+++ b/news/index.md
@@ -1,6 +1,8 @@
 ---
 layout: default
+title: News
 ---
+
 News
 ====
 

--- a/wargames/abraxas/index.md
+++ b/wargames/abraxas/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 listgames: true
+title: [RELEASED] Abraxas (HES2011)
 ---
+
 [RELEASED] Abraxas (HES2011)
 ============================
 

--- a/wargames/bandit/index.md
+++ b/wargames/bandit/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: bandit
+title: Bandit
 ---
+
 Bandit
 ======
 

--- a/wargames/behemoth/index.md
+++ b/wargames/behemoth/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: behemoth
+title: Behemoth
 ---
+
 Behemoth
 ========
 

--- a/wargames/blacksun/reading_material.md
+++ b/wargames/blacksun/reading_material.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: blacksun
+title: Reading material
 ---
+
 Reading material
 ================
 

--- a/wargames/drifter/index.md
+++ b/wargames/drifter/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: drifter
+title: Drifter
 ---
+
 Drifter
 =======
 

--- a/wargames/hes2010/index.md
+++ b/wargames/hes2010/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 listgames: true
+title: [RELEASED] HES2010
 ---
 
 [RELEASED] HES2010

--- a/wargames/index.md
+++ b/wargames/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 listgames: true
+title: Wargames
 ---
 
 Wargames

--- a/wargames/kishi/index.md
+++ b/wargames/kishi/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 listgames: true
+title: [RELEASED] Kishi (HES2013 and NSC2013)
 ---
+
 [RELEASED] Kishi (HES2013 and NSC2013)
 ======================================
 

--- a/wargames/krypton/index.md
+++ b/wargames/krypton/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: krypton
+title: Krypton
 ---
+
 Krypton
 =======
 

--- a/wargames/leviathan/index.md
+++ b/wargames/leviathan/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: leviathan
+title: Leviathan
 ---
+
 Leviathan
 =========
 

--- a/wargames/manpage/index.md
+++ b/wargames/manpage/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: manpage
+title: Manpage
 ---
+
 Manpage
 =======
 

--- a/wargames/maze/index.md
+++ b/wargames/maze/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: maze
+title: Maze
 ---
+
 Maze
 ====
 

--- a/wargames/monxla/index.md
+++ b/wargames/monxla/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 listgames: true
+title: [RELEASED] Monxla (HES2012)
 ---
+
 [RELEASED] Monxla (HES2012)
 ===========================
 

--- a/wargames/narnia/index.md
+++ b/wargames/narnia/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: narnia
+title: Narnia
 ---
+
 Narnia
 ======
 

--- a/wargames/natas/index.md
+++ b/wargames/natas/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: natas
+title: Natas
 ---
+
 Natas
 =====
 

--- a/wargames/semtex/index.md
+++ b/wargames/semtex/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: semtex
+title: Semtex
 ---
+
 Semtex
 ======
 

--- a/wargames/utumno/index.md
+++ b/wargames/utumno/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: utumno
+title: Utumno
 ---
+
 Utumno
 ======
 

--- a/wargames/vortex/index.md
+++ b/wargames/vortex/index.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 gamename: vortex
+title: Vortex
 ---
+
 Vortex
 ======
 


### PR DESCRIPTION
update: Added title attribute where appropriate …
- Added title attribute to those pages where there already was a h1
  heading which could be considered a title anyway.
  
  Sidenote: in the spirit of the awesome games offered by OverTheWire
  this change has been done via the following oneliner
  
  ```
    perl -0777 -pi -e 's/---\R\R?(.*?)\R==/title: \1\n---\n\n\1\n==/;' *.md
  ```
  
  which should work with perl 5.10 and later.

---

update: Setting webpage title more effectively …
- Rather than just putting the page title into <title> tags, this commit
  prepends it with 'OverTheWire: ' which arguably looks better from both
  UI and SEO standpoints.

---

First of all, thanks a ton for awesome games!

I am not sure if it was intentional but I've noticed that there were no titles (as in there was no content inside the `<title>` tags) on every page I've checked. 

These two commits should fix that.
