### PR TITLE
update: Fixed right arrow in webpage title

### DIFF
--- a/js/otwcrap.js
+++ b/js/otwcrap.js
@@ -79,7 +79,7 @@ function renderLevelTitle(name, level) {
         newDiv.innerHTML = "<h1>"+title+"</h1>";
 
         // also set the webpage title
-        document.title += ": " + title;
+        document.title += ": " + title.replace('&rarr;', '\u2192');
     };
     oReq.open("GET", "/games.json", true);
     oReq.send();


### PR DESCRIPTION
- The javascript code which generated the webpage title used an html
  entity which did not render in the browser. This commit tries to fix
  this problem.

Signed-off-by: mr.Shu mr@shu.io

---

@StevenVanAcker one more fix today -- sorry, this one is my bad, I haven't realized what would that JavaScript code do.
