### PR TITLE
clarify bandit16->bandit17 level goal

### DIFF
--- a/wargames/bandit/bandit17.md
+++ b/wargames/bandit/bandit17.md
@@ -5,7 +5,7 @@ level: 17
 ---
 Level Goal
 ----------
-The password for the next level can be retrieved by submitting the
+The credentials for the next level can be retrieved by submitting the
 password of the current level to **a port on localhost in the range
 31000 to 32000**. First find out which of these ports have a server
 listening on them. Then find out which of those speak SSL and which


### PR DESCRIPTION
The wording seems misleading, as solving the level does not give the player a password. The level goal later states "give credentials" which sounds like a better description.
