### PR TITLE
add "Ascii shellcode" reading material

### DIFF
--- a/wargames/behemoth/behemoth8.md
+++ b/wargames/behemoth/behemoth8.md
@@ -3,4 +3,8 @@ layout: default
 gamename: behemoth
 level: 8
 ---
-There is no information for this level, intentionally.
+Reading Material
+----------------
+- [Ascii shellcode][]
+
+[Ascii shellcode]: https://nets.ec/Ascii_shellcode


### PR DESCRIPTION
I found this level to be very challenging and the proposed reading material to be very helpful.  The binary for this level prints the message "Non-alpha chars found in string, possible shellcode!" depending on user input, so I don't think the link spoils anything.
