### PR TITLE
Lessened confusion: Substituted -ign_eof for -quiet

### DIFF
--- a/wargames/bandit/bandit16.md
+++ b/wargames/bandit/bandit16.md
@@ -10,7 +10,7 @@ password of the current level to **port 30001 on localhost** using
 SSL encryption.
 
  **Helpful note: Getting "HEARTBEATING" and "Read R BLOCK"? Use
--quiet and read the "CONNECTED COMMANDS" section in the manpage.
+--ign_eof and read the "CONNECTED COMMANDS" section in the manpage.
 Next to 'R' and 'Q', the 'B' command also works in this version of
 that command...**
 

--- a/wargames/bandit/bandit16.md
+++ b/wargames/bandit/bandit16.md
@@ -10,7 +10,7 @@ password of the current level to **port 30001 on localhost** using
 SSL encryption.
 
  **Helpful note: Getting "HEARTBEATING" and "Read R BLOCK"? Use
---ign_eof and read the "CONNECTED COMMANDS" section in the manpage.
+-ign_eof and read the "CONNECTED COMMANDS" section in the manpage.
 Next to 'R' and 'Q', the 'B' command also works in this version of
 that command...**
 


### PR DESCRIPTION
Substituted -ign_eof for -quiet to avoid confusion:
Using -quiet suggests that we want to see less information, which is not the point. What really want to do is a side effect of -quiet which is the  invokation of -ign_eof. Why not just do this?

Discussion/Confusion:
https://www.reddit.com/r/HowToHack/comments/2jixkl/going_through_bandit_wargames_at_overthewire_and/
