### PR TITLE
Clarified that user is not looking for password

### DIFF
--- a/wargames/bandit/bandit17.md
+++ b/wargames/bandit/bandit17.md
@@ -9,7 +9,8 @@ The credentials for the next level can be retrieved by submitting the
 password of the current level to **a port on localhost in the range
 31000 to 32000**. First find out which of these ports have a server
 listening on them. Then find out which of those speak SSL and which
-don't. There is only 1 server that will give the next credentials, the
+don't. There is only 1 server that will respond successfully and 
+provide private SSH keys to use and access the next level, the
 others will simply send back to you whatever you send to it.
 
 Commands you may need to solve this level


### PR DESCRIPTION
Clarified that a private SSH key is being looked for as a successful response (not a password)