### PR TITLE
Fixed external link

### DIFF
--- a/wargames/vortex/vortex11.md
+++ b/wargames/vortex/vortex11.md
@@ -18,7 +18,7 @@ Reading Material
 {% include showFile.html path="vortex11.c" %}
 {% include showFile.html path="phkmalloc.c" %}
 
-[BSD Heap Smashing]: http://freeworld.thc.org/root/docs/exploit_writing/BSD-heap-smashing.txt
+[BSD Heap Smashing]: http://www.ouah.org/BSD-heap-smashing.txt
 [Once upon a free()]: http://www.phrack.org/issues.html?issue=57&id=9#article
 [Advanced Doug Lea's malloc exploits]: http://www.phrack.org/issues.html?issue=61&id=6#article
 [Exploiting the Wilderness]: http://archive.cert.uni-stuttgart.de/vuln-dev/2004/02/msg00025.html


### PR DESCRIPTION
The BSD Heap Smashing link is dead. 
New link has identical text. Proof: https://web.archive.org/web/20120502090549/http://freeworld.thc.org/root/docs/exploit_writing/BSD-heap-smashing.txt