### PR TITLE
Drifter 3: Fix url to recommended reading

### DIFF
--- a/wargames/drifter/drifter3.md
+++ b/wargames/drifter/drifter3.md
@@ -9,4 +9,4 @@ implementation so it should be easily exploitable :)
 
 [Once upon a free()...][] - suitable reading material, amongst others.
 
-  [Once upon a free()...]: http://www.phrack.org/archives/57/p57-0x09
+  [Once upon a free()...]: http://phrack.org/archives/issues/57/9.txt


### PR DESCRIPTION
http://overthewire.org/wargames/drifter/drifter3.html points to http://www.phrack.org/archives/57/p57-0x09, but that URL doesn't seem to exist anymore