### PR TITLE
Updated message for VM users.

### DIFF
--- a/wargames/bandit/index.md
+++ b/wargames/bandit/index.md
@@ -47,7 +47,7 @@ continue:
 You're ready to start! Begin with [Level 0][], linked at the left of
 this page. Good luck!
 
-Note VMs: For unknown reasons, an error is produced sometimes when the VM network is attached to NAT (“broken pipe error”). To solve it, change the adapter to Bridged mode. 
+**Note for VMs:** You may fail to connect to overthewire.org via SSH with a "*broken pipe error*” when the network adapter for the VM is configured to use NAT mode. Adding the setting **`IPQoS throughput`** to `/etc/ssh/ssh_config` should resolve the issue. If this does not solve your issue, the only option then is to change the adapter to Bridged mode. 
 
   [Level 1]: /wargames/bandit/bandit1.html
   [Level 0]: /wargames/bandit/bandit0.html


### PR DESCRIPTION
Updated the message for those VM users experiencing the "broken pipe error" issue when connecting to OverTheWire via SSH. Adding "IPQoS throughput" corrects this issue without having to use Bridged mode.