### PR TITLE
Replace broken link to piping and redirection

### DIFF
--- a/wargames/bandit/bandit9.md
+++ b/wargames/bandit/bandit9.md
@@ -14,6 +14,6 @@ grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd
 
 Helpful Reading Material
 ------------------------
-- [The unix commandline: pipes and redirects][]
+- [Piping and Redirection][]
 
-[The unix commandline: pipes and redirects]: http://www.westwind.com/reference/os-x/commandline/pipes.html
+[Piping and Redirection]: https://ryanstutorials.net/linuxtutorial/piping.php


### PR DESCRIPTION
The link is broken and the site also has an invalid ssl certificate. I picked something from ryanstutorials instead, which has been around for a while and seems a good and stable resource.