### PR TITLE
feat: add overflow-x: auto to code blocks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -177,6 +177,10 @@ pre.standalone {
     padding: 20px 10px 10px 10px;
 }
 
+code {
+  overflow-x: auto;
+}
+
 dl dt {
     font-size: 13.5pt;
     font-weight: normal;


### PR DESCRIPTION
Adjusting overflow prevents weird behavior of code blocks in small windows.

before:
![Screenshot from 2020-04-21 23-20-22](https://user-images.githubusercontent.com/14118472/79934881-f78d9c80-8429-11ea-95da-c4437c55cc4f.png)

after:
![Screenshot from 2020-04-21 23-36-39](https://user-images.githubusercontent.com/14118472/79934898-01af9b00-842a-11ea-913d-b5f13f0dd198.png)
