### PR TITLE
Add online manpage links to early bandit

### DIFF
--- a/wargames/bandit/bandit0.md
+++ b/wargames/bandit/bandit0.md
@@ -14,7 +14,7 @@ logged in, go to the [Level 1][] page to find out how to beat Level
 
 Commands you may need to solve this level
 -----------------------------------------
-ssh
+[ssh](https://man7.org/linux/man-pages/man1/ssh.1.html)
 
 Helpful Reading Material
 ------------------------

--- a/wargames/bandit/bandit1.md
+++ b/wargames/bandit/bandit1.md
@@ -12,5 +12,15 @@ use SSH (on port 2220) to log into that level and continue the game.
 
 Commands you may need to solve this level
 -----------------------------------------
-ls, cd, cat, file, du, find
+[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+,
+[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+,
+[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+,
+[file](https://man7.org/linux/man-pages/man1/file.1.html)
+,
+[du](https://man7.org/linux/man-pages/man1/du.1.html)
+,
+[find](https://man7.org/linux/man-pages/man1/find.1.html)
 

--- a/wargames/bandit/bandit2.md
+++ b/wargames/bandit/bandit2.md
@@ -10,7 +10,17 @@ located in the home directory
 
 Commands you may need to solve this level
 -----------------------------------------
-ls, cd, cat, file, du, find
+[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+,
+[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+,
+[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+,
+[file](https://man7.org/linux/man-pages/man1/file.1.html)
+,
+[du](https://man7.org/linux/man-pages/man1/du.1.html)
+,
+[find](https://man7.org/linux/man-pages/man1/find.1.html)
 
 Helpful Reading Material
 ------------------------

--- a/wargames/bandit/bandit3.md
+++ b/wargames/bandit/bandit3.md
@@ -10,7 +10,17 @@ in this filename** located in the home directory
 
 Commands you may need to solve this level
 -----------------------------------------
-ls, cd, cat, file, du, find
+[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+,
+[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+,
+[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+,
+[file](https://man7.org/linux/man-pages/man1/file.1.html)
+,
+[du](https://man7.org/linux/man-pages/man1/du.1.html)
+,
+[find](https://man7.org/linux/man-pages/man1/find.1.html)
 
 Helpful Reading Material
 ------------------------

--- a/wargames/bandit/bandit4.md
+++ b/wargames/bandit/bandit4.md
@@ -10,5 +10,15 @@ The password for the next level is stored in a hidden file in the
 
 Commands you may need to solve this level
 -----------------------------------------
-ls, cd, cat, file, du, find
+[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+,
+[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+,
+[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+,
+[file](https://man7.org/linux/man-pages/man1/file.1.html)
+,
+[du](https://man7.org/linux/man-pages/man1/du.1.html)
+,
+[find](https://man7.org/linux/man-pages/man1/find.1.html)
 

--- a/wargames/bandit/bandit5.md
+++ b/wargames/bandit/bandit5.md
@@ -11,5 +11,15 @@ up, try the "reset" command.
 
 Commands you may need to solve this level
 -----------------------------------------
-ls, cd, cat, file, du, find
+[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+,
+[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+,
+[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+,
+[file](https://man7.org/linux/man-pages/man1/file.1.html)
+,
+[du](https://man7.org/linux/man-pages/man1/du.1.html)
+,
+[find](https://man7.org/linux/man-pages/man1/find.1.html)
 

--- a/wargames/bandit/bandit6.md
+++ b/wargames/bandit/bandit6.md
@@ -13,5 +13,15 @@ the **inhere** directory and has all of the following properties:
 
 Commands you may need to solve this level
 -----------------------------------------
-ls, cd, cat, file, du, find
+[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+,
+[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+,
+[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+,
+[file](https://man7.org/linux/man-pages/man1/file.1.html)
+,
+[du](https://man7.org/linux/man-pages/man1/du.1.html)
+,
+[find](https://man7.org/linux/man-pages/man1/find.1.html)
 

--- a/wargames/bandit/bandit7.md
+++ b/wargames/bandit/bandit7.md
@@ -13,5 +13,17 @@ server** and has all of the following properties:
 
 Commands you may need to solve this level
 -----------------------------------------
-ls, cd, cat, file, du, find, grep
+[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+,
+[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+,
+[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+,
+[file](https://man7.org/linux/man-pages/man1/file.1.html)
+,
+[du](https://man7.org/linux/man-pages/man1/du.1.html)
+,
+[find](https://man7.org/linux/man-pages/man1/find.1.html)
+,
+[grep](https://man7.org/linux/man-pages/man1/grep.1.html)
 

--- a/wargames/bandit/bandit8.md
+++ b/wargames/bandit/bandit8.md
@@ -10,4 +10,5 @@ next to the word **millionth**
 
 Commands you may need to solve this level
 -----------------------------------------
+[man](https://man7.org/linux/man-pages/man1/man.1.html),
 grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd

--- a/wargames/bandit/index.md
+++ b/wargames/bandit/index.md
@@ -27,16 +27,18 @@ sidemenu on the left of this page.
 You will encounter many situations in which you have no idea what you
 are supposed to do. **Don't panic! Don't give up!** The purpose of this
 game is for you to learn the basics. Part of learning the basics, is
-reading a lot of new information.
+reading a lot of new information. If you've never used the command line
+before, a good first read is this [introduction to user commands][].
 
 There are several things you can try when you are unsure how to
 continue:
 
 -   First, if you know a command, but don't know how to use it, try the
-    **manual** ([man page][]) by entering "**man <command\>**" (without
-    the quotes). e.g. if you know about the "ls" command, type: man ls.
-    The "man" command also has a manual, try it. Press q to quit the man
-    command.
+    **manual** ([man page][]) by entering **man <command\>**.
+    For example, **man ls** to learn about the "ls" command.
+    The "man" command also has a manual, try it!
+    When using **man**, press `q` to quit
+    (you can also use `/` and `n` and `N` to search).
 -   Second, if there is no man page, the command might be a **shell
     built-in**. In that case use the "**help <X\>**" command. E.g. help
     cd
@@ -51,6 +53,7 @@ this page. Good luck!
 
   [Level 1]: /wargames/bandit/bandit1.html
   [Level 0]: /wargames/bandit/bandit0.html
+  [introduction to user commands]: https://man7.org/linux/man-pages/man1/intro.1.html
   [man page]: http://en.wikipedia.org/wiki/Man_page
   [Google]: http://www.google.com
   [join us via chat]: /information/chat.html


### PR DESCRIPTION
Added links to https://man7.org/linux/man-pages/ for each of the "Commands you may need..." in bandit levels 0-7 and added a nudge to use the `man` command in bandit8. Also added an "intro to user commands" in bandit's main page. 

Rational for the change being: 
Early banditeers are told they need to read a lot and that the manual is helpful, but there is no relevant manuals for them to read. From bandit1 to bandit9, there's only a couple links to google searches and one to "advanced bash scripting guide". 

If you're being introduced to linux CLI via bandit, reading manpages via the `man` command is a bit difficult. Using a more familiar web UX will hopefully help out banditeers stuck on earlier levels and get them to start reading manpages.