### PR TITLE
Add port number to repository link in Bandit 28-32

### DIFF
--- a/wargames/bandit/bandit28.md
+++ b/wargames/bandit/bandit28.md
@@ -5,7 +5,7 @@ level: 28
 ---
 Level Goal
 ----------
-There is a git repository at `ssh://bandit27-git@localhost/home/bandit27-git/repo`. The password for the user `bandit27-git` is the same as for the user `bandit27`.
+There is a git repository at `ssh://bandit27-git@localhost:2220/home/bandit27-git/repo`. The password for the user `bandit27-git` is the same as for the user `bandit27`.
 
 Clone the repository and find the password for the next level.
 

--- a/wargames/bandit/bandit29.md
+++ b/wargames/bandit/bandit29.md
@@ -5,7 +5,7 @@ level: 29
 ---
 Level Goal
 ----------
-There is a git repository at `ssh://bandit28-git@localhost/home/bandit28-git/repo`. The password for the user `bandit28-git` is the same as for the user `bandit28`.
+There is a git repository at `ssh://bandit28-git@localhost:2220/home/bandit28-git/repo`. The password for the user `bandit28-git` is the same as for the user `bandit28`.
 
 Clone the repository and find the password for the next level.
 

--- a/wargames/bandit/bandit30.md
+++ b/wargames/bandit/bandit30.md
@@ -5,7 +5,7 @@ level: 30
 ---
 Level Goal
 ----------
-There is a git repository at `ssh://bandit29-git@localhost/home/bandit29-git/repo`. The password for the user `bandit29-git` is the same as for the user `bandit29`.
+There is a git repository at `ssh://bandit29-git@localhost:2220/home/bandit29-git/repo`. The password for the user `bandit29-git` is the same as for the user `bandit29`.
 
 Clone the repository and find the password for the next level.
 

--- a/wargames/bandit/bandit31.md
+++ b/wargames/bandit/bandit31.md
@@ -5,7 +5,7 @@ level: 31
 ---
 Level Goal
 ----------
-There is a git repository at `ssh://bandit30-git@localhost/home/bandit30-git/repo`. The password for the user `bandit30-git` is the same as for the user `bandit30`.
+There is a git repository at `ssh://bandit30-git@localhost:2220/home/bandit30-git/repo`. The password for the user `bandit30-git` is the same as for the user `bandit30`.
 
 Clone the repository and find the password for the next level.
 

--- a/wargames/bandit/bandit32.md
+++ b/wargames/bandit/bandit32.md
@@ -5,7 +5,7 @@ level: 32
 ---
 Level Goal
 ----------
-There is a git repository at `ssh://bandit31-git@localhost/home/bandit31-git/repo`. The password for the user `bandit31-git` is the same as for the user `bandit31`.
+There is a git repository at `ssh://bandit31-git@localhost:2220/home/bandit31-git/repo`. The password for the user `bandit31-git` is the same as for the user `bandit31`.
 
 Clone the repository and find the password for the next level.
 


### PR DESCRIPTION
In all 5 of these challenges, I wasn't able to clone the repo until I added the port number to the repository link. Not sure if this was supposed to be part of the challenge but figured I'd fix and PR in case it wasn't.