### PR TITLE
docs: add zsh wechall setup description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![CI](https://github.com/TheNewThinkTank/OverTheWire-website/actions/workflows/wf.yml/badge.svg)
 # Wargames
 
 The wargames offered by the OverTheWire community can help you to learn and practice security concepts in the form of fun-filled games.

--- a/information/wechall.md
+++ b/information/wechall.md
@@ -24,6 +24,8 @@ you need to follow these steps:
         export WECHALLUSER="YourUserName"
         export WECHALLTOKEN="YOUR-WECHALL-TOKEN-HERE"
 
+    For `zsh` users, edit your ~/.zshrc file exactly as above.
+
     For `fish` users, you may run:
 
         set -Ux WECHALLUSER "YourUserName"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "OverTheWire-website"
+version = "0.1.0"
+description = "OverTheWire website"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+# pytest = "^7.4.0"
+# pytest-cov = "^4.1.0"
+flake8 = "^6.1.0"
+ruff = "^0.0.280"
+mypy = "^1.4.1"
+# wily = "^1.24.2"
+# sphinx = "^7.1.1"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Added small section for zsh users, in order to locate the local file to update for wechall scoreboard setup