### PR TITLE
Warn against using powershell for bandit26

### DIFF
--- a/wargames/bandit/bandit26.md
+++ b/wargames/bandit/bandit26.md
@@ -9,6 +9,11 @@ Logging in to bandit26 from bandit25 should be fairly easy...
 The shell for user bandit26 is not **/bin/bash**, but something else.
 Find out what it is, how it works and how to break out of it.
 
+> NOTE: if you're a Windows user and typically use Powershell to
+> `ssh` into bandit: Powershell is known to cause issues with the
+> intended solution to this level. You should use command prompt
+> instead.
+
 Commands you may need to solve this level
 -----------------------------------------
 ssh, cat, more, vi, ls, id, pwd


### PR DESCRIPTION
Using powershell as the ssh shell for connecting to bandit has some quirks for this particular level that prevent the intended solution from working. Advise Windows-based players to not use powershell for bandit 25->26.