### PR TITLE
Bandit link cleanup

### DIFF
--- a/wargames/bandit/bandit0.md
+++ b/wargames/bandit/bandit0.md
@@ -22,5 +22,5 @@ Helpful Reading Material
 - [How to use SSH on wikiHow][]
 
 [Level 1]: /wargames/bandit/bandit1.html
-[Secure Shell (SSH) on Wikipedia]: http://en.wikipedia.org/wiki/Secure_Shell
-[How to use SSH on wikiHow]: http://www.wikihow.com/Use-SSH
+[Secure Shell (SSH) on Wikipedia]: https://en.wikipedia.org/wiki/Secure_Shell
+[How to use SSH on wikiHow]: https://www.wikihow.com/Use-SSH

--- a/wargames/bandit/bandit0.md
+++ b/wargames/bandit/bandit0.md
@@ -14,7 +14,7 @@ logged in, go to the [Level 1][] page to find out how to beat Level
 
 Commands you may need to solve this level
 -----------------------------------------
-[ssh](https://man7.org/linux/man-pages/man1/ssh.1.html)
+[ssh](https://manpages.ubuntu.com/manpages/noble/man1/ssh.1.html)
 
 Helpful Reading Material
 ------------------------

--- a/wargames/bandit/bandit1.md
+++ b/wargames/bandit/bandit1.md
@@ -12,17 +12,17 @@ use SSH (on port 2220) to log into that level and continue the game.
 
 Commands you may need to solve this level
 -----------------------------------------
-[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+[ls](https://manpages.ubuntu.com/manpages/noble/man1/ls.1.html)
 ,
-[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+[cd](https://manpages.ubuntu.com/manpages/noble/man1/cd.1posix.html)
 ,
-[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+[cat](https://manpages.ubuntu.com/manpages/noble/man1/cat.1.html)
 ,
-[file](https://man7.org/linux/man-pages/man1/file.1.html)
+[file](https://manpages.ubuntu.com/manpages/noble/man1/file.1.html)
 ,
-[du](https://man7.org/linux/man-pages/man1/du.1.html)
+[du](https://manpages.ubuntu.com/manpages/noble/man1/du.1.html)
 ,
-[find](https://man7.org/linux/man-pages/man1/find.1.html)
+[find](https://manpages.ubuntu.com/manpages/noble/man1/find.1.html)
 
 **TIP:** Create a file for notes and passwords on your local machine!
 

--- a/wargames/bandit/bandit11.md
+++ b/wargames/bandit/bandit11.md
@@ -16,4 +16,4 @@ Helpful Reading Material
 ------------------------
 - [Base64 on Wikipedia][]
 
-[Base64 on Wikipedia]: http://en.wikipedia.org/wiki/Base64
+[Base64 on Wikipedia]: https://en.wikipedia.org/wiki/Base64

--- a/wargames/bandit/bandit12.md
+++ b/wargames/bandit/bandit12.md
@@ -17,4 +17,4 @@ Helpful Reading Material
 ------------------------
 - [Rot13 on Wikipedia][]
 
-[Rot13 on Wikipedia]: http://en.wikipedia.org/wiki/Rot13
+[Rot13 on Wikipedia]: https://en.wikipedia.org/wiki/ROT13

--- a/wargames/bandit/bandit13.md
+++ b/wargames/bandit/bandit13.md
@@ -23,4 +23,4 @@ cp, mv, file
 
 - [Hex dump on Wikipedia][]
 
-[Hex dump on Wikipedia]: http://en.wikipedia.org/wiki/Hex_dump
+[Hex dump on Wikipedia]: https://en.wikipedia.org/wiki/Hex_dump

--- a/wargames/bandit/bandit15.md
+++ b/wargames/bandit/bandit15.md
@@ -23,8 +23,8 @@ accurate, but good enough for beginners)
 - [Port (computer networking) on Wikipedia][]
 
 [How the Internet works in 5 minutes (YouTube)]: https://www.youtube.com/watch?v=7_LPdttKXPc
-[IP Addresses]: http://computer.howstuffworks.com/web-server5.htm
-[IP Address on Wikipedia]: http://en.wikipedia.org/wiki/IP_address
-[Localhost on Wikipedia]: http://en.wikipedia.org/wiki/Localhost
-[Ports]: http://computer.howstuffworks.com/web-server8.htm
-[Port (computer networking) on Wikipedia]: http://en.wikipedia.org/wiki/Port_(computer_networking)
+[IP Addresses]: https://computer.howstuffworks.com/web-server5.htm
+[IP Address on Wikipedia]: https://en.wikipedia.org/wiki/IP_address
+[Localhost on Wikipedia]: https://en.wikipedia.org/wiki/Localhost
+[Ports]: https://computer.howstuffworks.com/web-server8.htm
+[Port (computer networking) on Wikipedia]: https://en.wikipedia.org/wiki/Port_(computer_networking)

--- a/wargames/bandit/bandit16.md
+++ b/wargames/bandit/bandit16.md
@@ -21,5 +21,5 @@ Helpful Reading Material
 - [Secure Socket Layer/Transport Layer Security on Wikipedia][]
 - [OpenSSL Cookbook - Testing with OpenSSL][]
 
-[Secure Socket Layer/Transport Layer Security on Wikipedia]: http://en.wikipedia.org/wiki/Secure_Socket_Layer
+[Secure Socket Layer/Transport Layer Security on Wikipedia]: https://en.wikipedia.org/wiki/Transport_Layer_Security
 [OpenSSL Cookbook - Testing with OpenSSL]: https://www.feistyduck.com/library/openssl-cookbook/online/testing-with-openssl/index.html

--- a/wargames/bandit/bandit17.md
+++ b/wargames/bandit/bandit17.md
@@ -23,4 +23,4 @@ Helpful Reading Material
 ------------------------
 - [Port scanner on Wikipedia][]
 
-[Port scanner on Wikipedia]: http://en.wikipedia.org/wiki/Port_scanner
+[Port scanner on Wikipedia]: https://en.wikipedia.org/wiki/Port_scanner

--- a/wargames/bandit/bandit2.md
+++ b/wargames/bandit/bandit2.md
@@ -28,4 +28,4 @@ Helpful Reading Material
 - [Advanced Bash-scripting Guide - Chapter 3 - Special Characters][]
 
 [Google Search for "dashed filename"]: https://www.google.com/search?q=dashed+filename
-[Advanced Bash-scripting Guide - Chapter 3 - Special Characters]: http://tldp.org/LDP/abs/html/special-chars.html
+[Advanced Bash-scripting Guide - Chapter 3 - Special Characters]: https://tldp.org/LDP/abs/html/special-chars.html

--- a/wargames/bandit/bandit2.md
+++ b/wargames/bandit/bandit2.md
@@ -10,17 +10,17 @@ located in the home directory
 
 Commands you may need to solve this level
 -----------------------------------------
-[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+[ls](https://manpages.ubuntu.com/manpages/noble/man1/ls.1.html)
 ,
-[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+[cd](https://manpages.ubuntu.com/manpages/noble/man1/cd.1posix.html)
 ,
-[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+[cat](https://manpages.ubuntu.com/manpages/noble/man1/cat.1.html)
 ,
-[file](https://man7.org/linux/man-pages/man1/file.1.html)
+[file](https://manpages.ubuntu.com/manpages/noble/man1/file.1.html)
 ,
-[du](https://man7.org/linux/man-pages/man1/du.1.html)
+[du](https://manpages.ubuntu.com/manpages/noble/man1/du.1.html)
 ,
-[find](https://man7.org/linux/man-pages/man1/find.1.html)
+[find](https://manpages.ubuntu.com/manpages/noble/man1/find.1.html)
 
 Helpful Reading Material
 ------------------------

--- a/wargames/bandit/bandit2.md
+++ b/wargames/bandit/bandit2.md
@@ -28,4 +28,4 @@ Helpful Reading Material
 - [Advanced Bash-scripting Guide - Chapter 3 - Special Characters][]
 
 [Google Search for "dashed filename"]: https://www.google.com/search?q=dashed+filename
-[Advanced Bash-scripting Guide - Chapter 3 - Special Characters]: https://tldp.org/LDP/abs/html/special-chars.html
+[Advanced Bash-scripting Guide - Chapter 3 - Special Characters]: https://linux.die.net/abs-guide/special-chars.html

--- a/wargames/bandit/bandit20.md
+++ b/wargames/bandit/bandit20.md
@@ -14,4 +14,4 @@ Helpful Reading Material
 ------------------------
 - [setuid on Wikipedia][]
 
-[setuid on Wikipedia]: http://en.wikipedia.org/wiki/Setuid
+[setuid on Wikipedia]: https://en.wikipedia.org/wiki/Setuid

--- a/wargames/bandit/bandit3.md
+++ b/wargames/bandit/bandit3.md
@@ -10,17 +10,17 @@ in this filename** located in the home directory
 
 Commands you may need to solve this level
 -----------------------------------------
-[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+[ls](https://manpages.ubuntu.com/manpages/noble/man1/ls.1.html)
 ,
-[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+[cd](https://manpages.ubuntu.com/manpages/noble/man1/cd.1posix.html)
 ,
-[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+[cat](https://manpages.ubuntu.com/manpages/noble/man1/cat.1.html)
 ,
-[file](https://man7.org/linux/man-pages/man1/file.1.html)
+[file](https://manpages.ubuntu.com/manpages/noble/man1/file.1.html)
 ,
-[du](https://man7.org/linux/man-pages/man1/du.1.html)
+[du](https://manpages.ubuntu.com/manpages/noble/man1/du.1.html)
 ,
-[find](https://man7.org/linux/man-pages/man1/find.1.html)
+[find](https://manpages.ubuntu.com/manpages/noble/man1/find.1.html)
 
 Helpful Reading Material
 ------------------------

--- a/wargames/bandit/bandit4.md
+++ b/wargames/bandit/bandit4.md
@@ -10,15 +10,15 @@ The password for the next level is stored in a hidden file in the
 
 Commands you may need to solve this level
 -----------------------------------------
-[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+[ls](https://manpages.ubuntu.com/manpages/noble/man1/ls.1.html)
 ,
-[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+[cd](https://manpages.ubuntu.com/manpages/noble/man1/cd.1posix.html)
 ,
-[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+[cat](https://manpages.ubuntu.com/manpages/noble/man1/cat.1.html)
 ,
-[file](https://man7.org/linux/man-pages/man1/file.1.html)
+[file](https://manpages.ubuntu.com/manpages/noble/man1/file.1.html)
 ,
-[du](https://man7.org/linux/man-pages/man1/du.1.html)
+[du](https://manpages.ubuntu.com/manpages/noble/man1/du.1.html)
 ,
-[find](https://man7.org/linux/man-pages/man1/find.1.html)
+[find](https://manpages.ubuntu.com/manpages/noble/man1/find.1.html)
 

--- a/wargames/bandit/bandit5.md
+++ b/wargames/bandit/bandit5.md
@@ -11,15 +11,15 @@ up, try the "reset" command.
 
 Commands you may need to solve this level
 -----------------------------------------
-[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+[ls](https://manpages.ubuntu.com/manpages/noble/man1/ls.1.html)
 ,
-[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+[cd](https://manpages.ubuntu.com/manpages/noble/man1/cd.1posix.html)
 ,
-[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+[cat](https://manpages.ubuntu.com/manpages/noble/man1/cat.1.html)
 ,
-[file](https://man7.org/linux/man-pages/man1/file.1.html)
+[file](https://manpages.ubuntu.com/manpages/noble/man1/file.1.html)
 ,
-[du](https://man7.org/linux/man-pages/man1/du.1.html)
+[du](https://manpages.ubuntu.com/manpages/noble/man1/du.1.html)
 ,
-[find](https://man7.org/linux/man-pages/man1/find.1.html)
+[find](https://manpages.ubuntu.com/manpages/noble/man1/find.1.html)
 

--- a/wargames/bandit/bandit6.md
+++ b/wargames/bandit/bandit6.md
@@ -13,15 +13,15 @@ the **inhere** directory and has all of the following properties:
 
 Commands you may need to solve this level
 -----------------------------------------
-[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+[ls](https://manpages.ubuntu.com/manpages/noble/man1/ls.1.html)
 ,
-[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+[cd](https://manpages.ubuntu.com/manpages/noble/man1/cd.1posix.html)
 ,
-[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+[cat](https://manpages.ubuntu.com/manpages/noble/man1/cat.1.html)
 ,
-[file](https://man7.org/linux/man-pages/man1/file.1.html)
+[file](https://manpages.ubuntu.com/manpages/noble/man1/file.1.html)
 ,
-[du](https://man7.org/linux/man-pages/man1/du.1.html)
+[du](https://manpages.ubuntu.com/manpages/noble/man1/du.1.html)
 ,
-[find](https://man7.org/linux/man-pages/man1/find.1.html)
+[find](https://manpages.ubuntu.com/manpages/noble/man1/find.1.html)
 

--- a/wargames/bandit/bandit7.md
+++ b/wargames/bandit/bandit7.md
@@ -13,17 +13,17 @@ server** and has all of the following properties:
 
 Commands you may need to solve this level
 -----------------------------------------
-[ls](https://man7.org/linux/man-pages/man1/ls.1.html)
+[ls](https://manpages.ubuntu.com/manpages/noble/man1/ls.1.html)
 ,
-[cd](https://man7.org/linux/man-pages/man1/cd.1p.html)
+[cd](https://manpages.ubuntu.com/manpages/noble/man1/cd.1posix.html)
 ,
-[cat](https://man7.org/linux/man-pages/man1/cat.1.html)
+[cat](https://manpages.ubuntu.com/manpages/noble/man1/cat.1.html)
 ,
-[file](https://man7.org/linux/man-pages/man1/file.1.html)
+[file](https://manpages.ubuntu.com/manpages/noble/man1/file.1.html)
 ,
-[du](https://man7.org/linux/man-pages/man1/du.1.html)
+[du](https://manpages.ubuntu.com/manpages/noble/man1/du.1.html)
 ,
-[find](https://man7.org/linux/man-pages/man1/find.1.html)
+[find](https://manpages.ubuntu.com/manpages/noble/man1/find.1.html)
 ,
-[grep](https://man7.org/linux/man-pages/man1/grep.1.html)
+[grep](https://manpages.ubuntu.com/manpages/noble/man1/grep.1.html)
 

--- a/wargames/bandit/bandit8.md
+++ b/wargames/bandit/bandit8.md
@@ -10,5 +10,5 @@ next to the word **millionth**
 
 Commands you may need to solve this level
 -----------------------------------------
-[man](https://man7.org/linux/man-pages/man1/man.1.html),
+[man](https://manpages.ubuntu.com/manpages/noble/man1/man.1.html),
 grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd

--- a/wargames/bandit/index.md
+++ b/wargames/bandit/index.md
@@ -54,6 +54,6 @@ this page. Good luck!
   [Level 1]: /wargames/bandit/bandit1.html
   [Level 0]: /wargames/bandit/bandit0.html
   [introduction to user commands]: https://man7.org/linux/man-pages/man1/intro.1.html
-  [man page]: http://en.wikipedia.org/wiki/Man_page
-  [Google]: http://www.google.com
+  [man page]: https://en.wikipedia.org/wiki/Man_page
+  [Google]: https://www.google.com
   [join us via chat]: /information/chat.html

--- a/wargames/bandit/index.md
+++ b/wargames/bandit/index.md
@@ -53,7 +53,7 @@ this page. Good luck!
 
   [Level 1]: /wargames/bandit/bandit1.html
   [Level 0]: /wargames/bandit/bandit0.html
-  [introduction to user commands]: https://man7.org/linux/man-pages/man1/intro.1.html
+  [introduction to user commands]: https://manpages.ubuntu.com/manpages/noble/man1/intro.1.html
   [man page]: https://en.wikipedia.org/wiki/Man_page
   [Google]: https://www.google.com
   [join us via chat]: /information/chat.html


### PR DESCRIPTION
This PR replaces:

- http:// links with their https:// counterpart
- man7.org manpages with Ubuntu manpages matching the current bandit VM
- the link to the TLDP's Advanced Bash-Scripting Guide with an equivalent alternative that is still up and running.