### PR TITLE
bandit16:The port number for providing the password is wrong.

### DIFF
--- a/wargames/bandit/bandit16.md
+++ b/wargames/bandit/bandit16.md
@@ -6,7 +6,7 @@ level: 16
 Level Goal
 ----------
 The password for the next level can be retrieved by submitting the
-password of the current level to **port 30001 on localhost** using
+password of the current level to **port 50001 on localhost** using
 SSL/TLS encryption.
 
  **Helpful note: Getting "DONE", "RENEGOTIATING" or "KEYUPDATE"? Read the


### PR DESCRIPTION
The port number for providing the password of the current level is mentioned as 30001 in the website. The port 30001 is not open and I tried submitting it to 50001 since I found it open from nmap scan and it worked. I've only made a minor change to the port number.

<img width="760" height="512" alt="image" src="https://github.com/user-attachments/assets/07ef97c9-1ed8-40eb-abe5-ab68fe0a07d9" />
